### PR TITLE
BEMの命名規則をもとに見直し

### DIFF
--- a/src/Eccube/Resource/template/admin/Product/category.twig
+++ b/src/Eccube/Resource/template/admin/Product/category.twig
@@ -93,10 +93,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% block main %}
     <div id="category" class="row">
         <div class="col-md-9">
-            <div id="category_content" class="box">
-                <div id="category_content__head" class="box-header">
-                    <div class="box-title box-title-category">
-                        <a href="{{ url('admin_product_category') }}">全カテゴリー</a>
+            <div id="category_box" class="box">
+                <div id="category_box__head" class="box-header">
+                    <div id="category_box__link_product_category" class="box-title box-title-category">
+                        <a id="link__product_category" href="{{ url('admin_product_category') }}">全カテゴリー</a>
                         {% for ParentCategory in TargetCategory.path %}
                             {% if ParentCategory.id is not null %}
                             &nbsp;<svg class="cb cb-angle-right"> <use xlink:href="#cb-angle-right" /></svg>&nbsp;<a href="{{ url('admin_product_category_show', { parent_id : ParentCategory.id }) }}">{{ ParentCategory.name }}</a>
@@ -104,23 +104,23 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         {% endfor %}
                     </div>
                 </div>
-                <div id="category_content__body" class="box-body">
-                    <div class="row">
-                        <div id="category_form" class="form-inline col-md-9">
+                <div id="category_box__body" class="box-body">
+                    <div id="category_box__menu" class="row">
+                        <div id="category_box__button_area_category_new" class="form-inline col-md-9">
                             {% if TargetCategory.level < app.config.category_nest_level %}
                             <form role="form" class="form-horizontal" name="form1" id="form1" method="post" action="{% if TargetCategory.id %}{{ path('admin_product_category_edit', {id: TargetCategory.id}) }}{% elseif Parent %}{{ url('admin_product_category_show', {'parent_id': Parent.id}) }}{% else %}{{ url('admin_product_category') }}{% endif %}" enctype="multipart/form-data">
                                 {{ form_widget(form._token) }}
                                 {{ form_widget(form.name, {attr: {placeholder: 'カテゴリ名を入力'}}) }}
                                 {{ form_errors(form.name) }}
-                                <button class="btn btn-default btn-sm" type="submit">カテゴリ作成</button>
+                                <button id="button__category_new" class="btn btn-default btn-sm" type="submit">カテゴリ作成</button>
                             </form>
                             {% endif %}
                         </div>
-                        <div id="category_csv" class="dl_dropdown col-md-3">
+                        <div id="category_box__csv_menu" class="dl_dropdown col-md-3">
                             <div class="dropdown"><a data-toggle="dropdown" class="dropdown-toggle" aria-expanded="false">CSVダウンロード<svg class="cb cb-angle-down icon_down"><use xlink:href="#cb-angle-down"/></svg></a>
                                 <ul class="dropdown-menu dropdown-menu-right">
-                                    <li><a href="{{ url('admin_product_category_export') }}">CSVダウンロード</a></li>
-                                    <li><a href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_CATEGORY') }) }}">出力項目設定</a></li>
+                                    <li id="category_box__link_product_category_export"><a id="link__product_category_export" href="{{ url('admin_product_category_export') }}">CSVダウンロード</a></li>
+                                    <li id="category_box__link_product_category_setting_shop_csv"><a id="link__product_category_setting_shop_csv" href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_CATEGORY') }) }}">出力項目設定</a></li>
                                 </ul>
                             </div>
                         </div>
@@ -133,28 +133,28 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
                                 {% for Category in Categories %}
 
-                                <div id="category_list__body__{{ Category.id }}" class="item_box tr" data-rank="{{ Category.rank }}" data-category-id="{{ Category.id }}">
+                                <div id="category_list__item--{{ Category.id }}" class="item_box tr" data-rank="{{ Category.rank }}" data-category-id="{{ Category.id }}">
                                     <div class="icon_sortable td">
                                         <svg class="cb cb-ellipsis-v"> <use xlink:href="#cb-ellipsis-v" /></svg>
                                     </div>
-                                    <div id="category_list__title__{{ Category.id }}" class="item_pattern td">
+                                    <div id="category_list__name--{{ Category.id }}" class="item_pattern td">
                                         <a href="{{ url('admin_product_category_show',  { parent_id : Category.id }) }}">{{ Category.name }}</a>
                                     </div>
-                                    <div id="category_list__edit__{{ Category.id }}" class="icon_edit td">
+                                    <div id="category_list__menu--{{ Category.id }}" class="icon_edit td">
                                         <div class="dropdown">
                                             <a class="dropdown-toggle" data-toggle="dropdown"><svg class="cb cb-ellipsis-h"> <use xlink:href="#cb-ellipsis-h" /></svg></a>
                                             <ul class="dropdown-menu dropdown-menu-right">
                                                 {% if Category.id != TargetCategory.id %}
-                                                    <li><a href="{{ url('admin_product_category_edit', {id: Category.id}) }}">編集</a></li>
+                                                    <li id="category_list__link_product_category_edit--{{ Category.id }}_enable"><a id="link__product_category_edit--{{ Category.id }}_enable" href="{{ url('admin_product_category_edit', {id: Category.id}) }}">編集</a></li>
                                                 {% else %}
-                                                    <li><a>編集中</a></li>
+                                                    <li id="category_list__link_product_category_edit--{{ Category.id }}_disable"><a id="link__product_category_edit--{{ Category.id }}_disable">編集中</a></li>
                                                 {% endif %}
 
                                                 {% if Category.Children|length > 0 or Category.ProductCategories|length > 0 %}
-                                                    <li><a title="子カテゴリが存在するため削除できません。">削除</a></li>
+                                                    <li id="category_list__link_product_category_delete--{{ Category.id }}_disable"><a id="link__product_category_delete--{{ Category.id }}_disable" title="子カテゴリが存在するため削除できません。">削除</a></li>
                                                 {% else %}
-                                                    <li>
-                                                        <a href="{{ url('admin_product_category_delete', {id: Category.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete">
+                                                    <li id="category_list__link_product_category_delete--{{ Category.id }}_enable">
+                                                        <a id="link__product_category_delete--{{ Category.id }}_enable" href="{{ url('admin_product_category_delete', {id: Category.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete">
                                                             削除
                                                         </a>
                                                     </li>
@@ -170,7 +170,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </div>
                     </div><!-- /.box-body -->
             {% else %}
-                <div id="category_list" class="box-body no-padding">
+                <div id="category_list__errror" class="box-body no-padding">
                     <div class="data-empty"><svg class="cb cb-inbox"> <use xlink:href="#cb-inbox" /></svg><p>データはありません</p></div>
                 </div><!-- /.box-body -->
             {% endif %}
@@ -180,14 +180,14 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
         {% macro tree(Category, TargetId, level) %}
             {% set level = level + 1 %}
-            <li class="level{{ level }} {% if Category.id == TargetId %}active{% endif %}">
+            <li id="category__link_product_category_show" class="level{{ level }} {% if Category.id == TargetId %}active{% endif %}">
                 <svg class="cb cb-plus-square"> <use xlink:href="{% if Category.children|length > 0 %}#cb-plus-square{% else %}#cb-minus-square{% endif %}" /></svg>
-                <a href="{{ url('admin_product_category_show', { parent_id : Category.id }) }}">
+                <a id="link__product_category_show" href="{{ url('admin_product_category_show', { parent_id : Category.id }) }}">
                     {{ Category.name }} ({{ Category.children|length }})
                 </a>
                 {% if Category.children|length > 0 %}
                     {% for ChildCategory in Category.children %}
-                        <ul>
+                        <ul id="category_child__link_product_category_show--{{ loop.index }}">
                             {{ _self.tree(ChildCategory, TargetId, level) }}
                         </ul>
                     {% endfor %}
@@ -195,13 +195,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             </li>
         {% endmacro %}
 
-        <div id="category_tree" class="col-md-3" id="aside_column">
+        <div class="col-md-3" id="aside_column">
             <div class="col_inner">
 
-                <div class="box no-header">
-                    <div class="box-body">
+                <div id="category_tree__box" class="box no-header">
+                    <div id="category_tree__body" class="box-body">
                         <div class="tree">
-                            <p  id="category_tree__name" class="{% if Parent is null %}active{% endif %}"><a href="{{ url('admin_product_category') }}">全カテゴリー</a></p>
+                            <p id="category_tree__link_tree_product_category"  class="{% if Parent is null %}active{% endif %}"><a id="link__tree_product_category" href="{{ url('admin_product_category') }}">全カテゴリー</a></p>
                             <ul id="category_tree">
                                 {% for TopCategory in TopCategories %}
                                     {{ _self.tree(TopCategory, TargetCategory.Parent.id | default(null), 0)}}

--- a/src/Eccube/Resource/template/admin/Product/class_category.twig
+++ b/src/Eccube/Resource/template/admin/Product/class_category.twig
@@ -80,16 +80,16 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% block main %}
     <div id="class_category" class="row">
         <div class="col-md-12">
-            <div class="box">
+            <div id="class_category_box" class="box">
                 <div class="box-header">
                     <h3 class="box-title">規格名： {{ ClassName.name }}</h3>
                 </div>
-                <div class="box-body">
-                    <div class="form-inline">
+                <div id="class_category_box__body" class="box-body">
+                    <div id="class_category_box__class_new" class="form-inline">
                         <form role="form" class="form-horizontal" name="form1" id="form1" method="post" action="{% if TargetClassCategory.id %}{{ url('admin_product_class_category_edit', {class_name_id: ClassName.id, id: TargetClassCategory.id}) }}{% else %}{{ url('admin_product_class_category', {'class_name_id': ClassName.id}) }}{% endif %}">
                             {{ form_widget(form._token) }}
                             {{ form_widget(form.name, {attr: {placeholder: '分類名を入力'}}) }}
-                            <button class="btn btn-default btn-sm" type="submit">分類作成</button>
+                            <button id="button__class_new" class="btn btn-default btn-sm" type="submit">分類作成</button>
                         </form>
                     </div>
                 </div><!-- /.box-header -->
@@ -100,28 +100,30 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
                                 {% for ClassCategory in ClassCategories %}
 
-                                    <div id="class_category_list__body__{{ ClassCategory.id }}" class="item_box tr" data-category-id="{{ ClassCategory.id }}" data-rank="{{ ClassCategory.rank }}">
+                                    <div id="class_category_list__menu--{{ ClassCategory.id }}"
+                                         class="item_box tr"
+                                         data-category-id="{{ ClassCategory.id }}" data-rank="{{ ClassCategory.rank }}">
                                         <div class="icon_sortable td">
                                             <svg class="cb cb-ellipsis-v"> <use xlink:href="#cb-ellipsis-v" /></svg>
                                         </div>
-                                        <div id="class_category_list__title__{{ Category.id }}" class="item_pattern td">
-                                            <a href="{{ url('admin_product_class_category_edit', {class_name_id: ClassName.id, id: ClassCategory.id}) }}">
+                                        <div id="class_category_list__name--{{ Category.id }}" class="item_pattern td">
+                                            <a id="link__product_class_category_edit" href="{{ url('admin_product_class_category_edit', {class_name_id: ClassName.id, id: ClassCategory.id}) }}">
                                                 {{ ClassCategory.name }}
                                             </a>
                                         </div>
-                                        <div id="class_category_list__edit__{{ Category.id }}" class="icon_edit td">
+                                        <div id="class_category_list__edit_menu--{{ Category.id }}" class="icon_edit td">
                                             <div class="dropdown">
                                                 <a class="dropdown-toggle" data-toggle="dropdown"><svg class="cb cb-ellipsis-h"> <use xlink:href="#cb-ellipsis-h" /></svg></a>
                                                 <ul class="dropdown-menu dropdown-menu-right">
                                                     {% if ClassCategory.id != TargetClassCategory.id %}
-                                                        <li>
-                                                            <a href="{{ url('admin_product_class_category_edit', {class_name_id: ClassName.id, id: ClassCategory.id}) }}">編集</a>
+                                                        <li id="class_category_list__link_product_class_category_edit--{{ ClassCategory.id }}_enable">
+                                                            <a id="link__product_class_category_edit--{{ ClassCategory.id }}_enable" href="{{ url('admin_product_class_category_edit', {class_name_id: ClassName.id, id: ClassCategory.id}) }}">編集</a>
                                                         </li>
                                                     {% else %}
-                                                        <li><a>編集中</a></li>
+                                                        <li id="class_category_list__link_product_class_category_edit--{{ ClassCategory.id }}_disable"><a id="link__product_class_category_edit--{{ ClassCategory.id }}_disable">編集中</a></li>
                                                     {% endif %}
-                                                    <li>
-                                                        <a href="{{ url('admin_product_class_category_delete', {class_name_id: ClassName.id, id: ClassCategory.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete"
+                                                    <li id="class_category_list__link_product_class_category_delete--{{ ClassCategory.id }}">
+                                                        <a id="link__product_class_category_delete--{{ ClassCategory.id }}" href="{{ url('admin_product_class_category_delete', {class_name_id: ClassName.id, id: ClassCategory.id }) }}" {{ csrf_token_for_anchor() }} data-method="delete"
                                                            data-message="分類名を削除すると、その分類を利用している商品規格が無効になります。整合性の問題を把握し、バックアップを行ってから削除することを推奨致します。">削除</a>
                                                     </li>
                                                 </ul>
@@ -134,7 +136,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </div>
                     </div><!-- /.box-body -->
                 {% else %}
-                    <div id="class_category_list" class="box-body no-padding">
+                    <div id="class_category_list__error" class="box-body no-padding">
                         <div class="data-empty"><svg class="cb cb-inbox"> <use xlink:href="#cb-inbox" /></svg><p>データはありません</p></div>
                     </div><!-- /.box-body -->
                 {% endif %}
@@ -142,9 +144,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             </div><!-- /.box -->
         </div><!-- /.col -->
     </div>
-    <div id="class_category_back" class="row">
+    <div id="class_category_list__link_product_class_name" class="row">
         <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
-            <p><a href="{{ url('admin_product_class_name') }}">規格一覧に戻る</a></p>
+            <p><a id="link__product_class_name" href="{{ url('admin_product_class_name') }}">規格一覧に戻る</a></p>
         </div>
     </div>
 

--- a/src/Eccube/Resource/template/admin/Product/class_name.twig
+++ b/src/Eccube/Resource/template/admin/Product/class_name.twig
@@ -80,52 +80,52 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% block main %}
     <div id="class_name" class="row">
         <div class="col-md-12">
-            <div id="class_name_content" class="box">
-                <div id="class_name_content__head" class="box-header">
-                    <div class="form-inline">
+            <div id="class_name_box" class="box">
+                <div id="class_name_box__head" class="box-header">
+                    <div id="class_name_box__button_class_name_new" class="form-inline">
                         <form role="form" class="form-horizontal" name="form1" id="form1" method="post" action="{% if TargetClassName.id %}{{ path('admin_product_class_name_edit', {id: TargetClassName.id}) }}{% else %}{{ url('admin_product_class_name') }}{% endif %}">
                             {{ form_widget(form._token) }}
                             {{ form_widget(form.name, {attr: {placeholder: '規格名を入力'}}) }}
                             {{ form_errors(form.name) }}
-                            <button class="btn btn-default btn-sm" type="submit">規格作成</button>
+                            <button id="button__class_name_new" class="btn btn-default btn-sm" type="submit">規格作成</button>
                         </form>
                     </div>
                 </div><!-- /.box-header -->
                 {% if ClassNames|length > 0 %}
-                    <div id="class_name_list" class="box-body no-padding no-border">
-                        <div class="sortable_list">
+                    <div id="class_name_box__body" class="box-body no-padding no-border">
+                        <div id="class_name__list" class="sortable_list">
                             <div class="tableish">
 
                                 {% for ClassName in ClassNames %}
 
-                                    <div id="class_name_list__body__{{ ClassName.id }}" class="item_box tr" data-class-name-id="{{ ClassName.id }}" data-rank="{{ ClassName.rank }}">
+                                    <div id="class_name_list__item--{{ ClassName.id }}" class="item_box tr" data-class-name-id="{{ ClassName.id }}" data-rank="{{ ClassName.rank }}">
                                         <div class="icon_sortable td">
                                             <svg class="cb cb-ellipsis-v"> <use xlink:href="#cb-ellipsis-v" /></svg>
                                         </div>
-                                        <div id="class_name_list__title__{{ ClassName.id }}" class="item_pattern td">
-                                            <a href="{{ url('admin_product_class_category', {class_name_id : ClassName.id }) }}">
+                                        <div id="class_name_list__name--{{ ClassName.id }}" class="item_pattern td">
+                                            <a id="link__product_class_category" href="{{ url('admin_product_class_category', {class_name_id : ClassName.id }) }}">
                                                 {{ ClassName.name }} ({{ ClassName.ClassCategories|length }})
                                             </a>
                                         </div>
-                                        <div id="class_name_list__edit__{{ ClassName.id }}" class="icon_edit td">
+                                        <div id="class_name_list__edit_menu--{{ ClassName.id }}" class="icon_edit td">
                                             <div class="dropdown">
                                                 <a class="dropdown-toggle" data-toggle="dropdown"><svg class="cb cb-ellipsis-h"> <use xlink:href="#cb-ellipsis-h" /></svg></a>
                                                 <ul class="dropdown-menu dropdown-menu-right">
-                                                    <li>
-                                                        <a href="{{ url('admin_product_class_category', {class_name_id : ClassName.id }) }}">
+                                                    <li id="class_name_list__link_edit_menu_product_class_category--{{ ClassName.id }}">
+                                                        <a id="link__menu_product_class_category--{{ ClassName.id }}" href="{{ url('admin_product_class_category', {class_name_id : ClassName.id }) }}">
                                                             分類登録
                                                         </a>
                                                     </li>
 
                                                     {% if ClassName.id != TargetClassName.id %}
-                                                        <li><a href="{{ url('admin_product_class_name_edit', {id: ClassName.id}) }}">編集</a></li>
+                                                        <li id="class_name_list__link_product_class_name_edit-{{ ClassName.id }}_enable"><a id="link__product_class_name_edit-{{ ClassName.id }}_enable" href="{{ url('admin_product_class_name_edit', {id: ClassName.id}) }}">編集</a></li>
                                                     {% else %}
-                                                        <li><a>編集中</a></li>
+                                                        <li id="class_name_list__link_product_class_name_edit-{{ ClassName.id }}_disable"><a id="link__product_class_name_edit-{{ ClassName.id }}_disable">編集中</a></li>
                                                     {% endif %}
 
                                                     {% if ClassName.ClassCategories|length == 0 %}
-                                                        <li>
-                                                            <a href="{{ url('admin_product_class_name_delete', {id: ClassName.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete">
+                                                        <li id="class_name_list__link_product_class_name_delete--{{ ClassName.id }}">
+                                                            <a id="link__product_class_name_delete--{{ ClassName.id }}" href="{{ url('admin_product_class_name_delete', {id: ClassName.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete">
                                                                 削除
                                                             </a>
                                                         </li>
@@ -141,7 +141,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                         </div>
                     </div><!-- /.box-body -->
                 {% else %}
-                    <div id="class_name_list" class="box-body no-padding">
+                    <div id="class_name_box__body_error" class="box-body no-padding">
                         <div class="data-empty"><svg class="cb cb-inbox"> <use xlink:href="#cb-inbox" /></svg><p>データはありません</p></div>
                     </div><!-- /.box-body -->
                 {% endif %}

--- a/src/Eccube/Resource/template/admin/Product/csv_category.twig
+++ b/src/Eccube/Resource/template/admin/Product/csv_category.twig
@@ -68,25 +68,25 @@ $(function() {
     <div class="col-md-12">
         <form id="upload-form" class="form-inline" method="post" action="{{ url('admin_product_category_csv_import') }}" {{ form_enctype(form) }}>
             {{ form_widget(form._token) }}
-            <div id="category_csv_upload__box" class="box">
-                <div id="category_csv_header" class="box-header">
+            <div id="category_csv_upload_box" class="box">
+                <div id="category_csv_upload_box__header" class="box-header">
                     <h3 class="box-title">カテゴリ登録CSV</h3>
                 </div><!-- /.box-header -->
-                <div id="category_csv_body" class="box-body">
-                    <div class="form-group">
-                        <label id="category_csv_body__label" class="col-sm-5 control-label">CSVファイル選択</label>
-                        <div id="category_csv_body__file" class="col-sm-7">
+                <div id="category_csv_upload_box__body" class="box-body">
+                    <div id="category_csv_box__import_file" class="form-group">
+                        <label class="col-sm-5 control-label">CSVファイル選択</label>
+                        <div class="col-sm-7">
                             {{ form_widget(form.import_file, {'attr': {'accept': 'text/csv,text/tsv'}}) }}
                             {{ form_errors(form.import_file) }}
                         </div>
                         {% for error in errors %}
-                            <div id="category_csv_body__error" class="text-danger">{{ error.message }}</div>
+                            <div id="category_csv_box__error--{{ loop.index }}" class="text-danger">{{ error.message }}</div>
                         {% endfor %}
                     </div>
                     <div id="spinner"></div>
                 </div><!-- /.box-body -->
                 <div id="category_csv_upload__button_area" class="box-footer text-center">
-                    <button id="upload-button" type="submit" class="btn btn-primary btn-sm">CSVファイルのアップロード</button>
+                    <button id="upload__button" type="submit" class="btn btn-primary btn-sm">CSVファイルのアップロード</button>
                 </div><!-- /.box-footer -->
             </div><!-- /.box -->
         </form>
@@ -95,27 +95,27 @@ $(function() {
 
 <div id="category_csv_file_format" class="row">
     <div class="col-md-12">
-        <div class="box">
-            <div id="category_csv_file_format__head" class="box-header">
-                <a href="{{ url('admin_product_csv_template', {'type': 'category'}) }}" id="download-button" class="btn btn-default pull-right btn-xs">雛形ファイルダウンロード</a>
+        <div id="category_csv_file_format_box" class="box">
+            <div id="category_csv_file_format_box__header" class="box-header">
+                <a id="link__product_csv_template" href="{{ url('admin_product_csv_template', {'type': 'category'}) }}" id="download-button" class="btn btn-default pull-right btn-xs">雛形ファイルダウンロード</a>
                 <h3 class="box-title">カテゴリ登録CSVファイルフォーマット</h3>
             </div><!-- /.box-header -->
-            <div id="category_csv_file_format__body" class="box-body no-padding">
-                <div class="table_list">
+            <div id="category_csv_file_format_box__body" class="box-body no-padding">
+                <div id="category_csv_file_format_list" class="table_list">
                     <div class="table-responsive no-border table-menu table-responsive-overflow">
                         <table class="table table-striped">
                             <thead>
-                                <tr id="file_format__head" class="text-nowrap">
+                                <tr id="category_csv_file_format_list__header" class="text-nowrap">
                                     {% for header in headers|keys %}
-                                        <th>{{ header }}</th>
+                                        <th id="category_csv_file_format_list__header--{{ loop.index }}">{{ header }}</th>
                                     {% endfor %}
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr id="file_format__body" class="text-nowrap">
-                                    <td>新規登録時は未設定<br>既存カテゴリの更新はカテゴリIDを設定</td>
-                                    <td>必須</td>
-                                    <td></td>
+                                <tr id="category_csv_file_format_list__body" class="text-nowrap">
+                                    <td id="category_csv_file_format_list__id">新規登録時は未設定<br>既存カテゴリの更新はカテゴリIDを設定</td>
+                                    <td id="category_csv_file_format_list__name">必須</td>
+                                    <td id="category_csv_file_format_list__parent_id"></td>
                                 </tr>
                             </tbody>
                         </table>

--- a/src/Eccube/Resource/template/admin/Product/csv_product.twig
+++ b/src/Eccube/Resource/template/admin/Product/csv_product.twig
@@ -68,25 +68,25 @@ $(function() {
     <div class="col-md-12">
         <form id="upload-form" class="form-inline" method="post" action="{{ url('admin_product_csv_import') }}" {{ form_enctype(form) }}>
             {{ form_widget(form._token) }}
-            <div id="product_csv_upload__box" class="box">
-                <div id="product_csv_header" class="box-header">
+            <div id="product_csv_upload_box" class="box">
+                <div id="product_csv_upload_box__header" class="box-header">
                     <h3 class="box-title">商品登録CSV</h3>
                 </div><!-- /.box-header -->
-                <div id="product_csv_body" class="box-body">
-                    <div class="form-group">
-                        <label id="product_csv_body__label" class="col-sm-5 control-label">CSVファイル選択</label>
-                        <div id="product_csv_body__file" class="col-sm-7">
+                <div id="product_csv_upload_box__body" class="box-body">
+                    <div id="product_csv_body__import_file" class="form-group">
+                        <label class="col-sm-5 control-label">CSVファイル選択</label>
+                        <div class="col-sm-7">
                             {{ form_widget(form.import_file, {'attr': {'accept': 'text/csv,text/tsv'}}) }}
                             {{ form_errors(form.import_file) }}
                         </div>
                         {% for error in errors %}
-                            <div id="product_csv_body__error" class="text-danger">{{ error.message }}</div>
+                            <div id="product_csv_upload_box__error--{{ loop.index }}" class="text-danger">{{ error.message }}</div>
                         {% endfor %}
                     </div>
                     <div id="spinner"></div>
                 </div><!-- /.box-body -->
-                <div id="product_csv_upload__button_area" class="box-footer text-center">
-                    <button id="upload-button" type="submit" class="btn btn-primary btn-sm">CSVファイルのアップロード</button>
+                <div id="product_csv_upload_box__button_area" class="box-footer text-center">
+                    <button id="upload__button" type="submit" class="btn btn-primary btn-sm">CSVファイルのアップロード</button>
                 </div><!-- /.box-footer -->
             </div><!-- /.box -->
         </form>
@@ -95,47 +95,47 @@ $(function() {
 
 <div id="product_csv_file_format" class="row">
     <div class="col-md-12">
-        <div class="box">
-            <div id="product_csv_file_format__head" class="box-header">
-                <a href="{{ url('admin_product_csv_template', {'type': 'product'}) }}" id="download-button" class="btn btn-default pull-right btn-xs">雛形ファイルダウンロード</a>
+        <div id="product_csv_file_format_box" class="box">
+            <div id="product_csv_file_format_box__header" class="box-header">
+                <a id="link__product_csv_template" href="{{ url('admin_product_csv_template', {'type': 'product'}) }}" id="download-button" class="btn btn-default pull-right btn-xs">雛形ファイルダウンロード</a>
                 <h3 class="box-title">商品登録CSVファイルフォーマット</h3>
             </div><!-- /.box-header -->
-            <div id="product_csv_file_format__body" class="box-body no-padding">
-                <div class="table_list">
+            <div id="product_csv_file_format_box__body" class="box-body no-padding">
+                <div id="product_csv_file_format_list" class="table_list">
                     <div class="table-responsive no-border table-menu table-responsive-overflow">
                         <table class="table table-striped">
                             <thead>
-                                <tr id="file_format__head" class="text-nowrap">
+                                <tr id="product_csv_file_format_list__header" class="text-nowrap">
                                     {% for header in headers|keys %}
-                                        <th>{{ header }}</th>
+                                        <th id="product_csv_file_format_list__header--{{ loop.index }}">{{ header }}</th>
                                     {% endfor %}
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr id="file_format__body" class="text-nowrap">
-                                    <td>新規登録時は未設定<br>既存商品の更新は商品IDを設定</td>
-                                    <td>必須</td>
-                                    <td>必須</td>
-                                    <td></td>
-                                    <td></td>
-                                    <td></td>
-                                    <td></td>
-                                    <td></td>
-                                    <td>設定されていない場合<br>0を登録</td>
-                                    <td>複数画像の場合<br>画像ファイル名をカンマ区切りで<br>「"」で囲んで設定</td>
-                                    <td>複数カテゴリの場合<br>商品カテゴリIDをカンマ区切りで<br>「"」で囲んで設定</td>
-                                    <td>必須</td>
-                                    <td></td>
-                                    <td></td>
-                                    <td></td>
-                                    <td></td>
-                                    <td>在庫数無制限フラグが0の場合<br>0以上の数値を設定</td>
-                                    <td>必須</td>
-                                    <td>0以上の数値を設定</td>
-                                    <td>0以上の数値を設定</td>
-                                    <td>必須<br>0以上の数値を設定</td>
-                                    <td>商品ごとの送料設定が有効の場合<br>0以上の数値を設定</td>
-                                    <td>設定されていない場合<br>0を登録</td>
+                                <tr id="product_csv_file_format_list__body" class="text-nowrap">
+                                    <td id="product_csv_file_format_list__id">新規登録時は未設定<br>既存商品の更新は商品IDを設定</td>
+                                    <td id="product_csv_file_format_list__status">必須</td>
+                                    <td id="product_csv_file_format_list__name">必須</td>
+                                    <td id="product_csv_file_format_list__shop_memo"></td>
+                                    <td id="product_csv_file_format_list__info"></td>
+                                    <td id="product_csv_file_format_list__detail"></td>
+                                    <td id="product_csv_file_format_list__search_word"></td>
+                                    <td id="product_csv_file_format_list__free"></td>
+                                    <td id="product_csv_file_format_list__delete_flg">設定されていない場合<br>0を登録</td>
+                                    <td id="product_csv_file_format_list__image">複数画像の場合<br>画像ファイル名をカンマ区切りで<br>「"」で囲んで設定</td>
+                                    <td id="product_csv_file_format_list__category">複数カテゴリの場合<br>商品カテゴリIDをカンマ区切りで<br>「"」で囲んで設定</td>
+                                    <td id="product_csv_file_format_list__type_id">必須</td>
+                                    <td id="product_csv_file_format_list__class_1"></td>
+                                    <td id="product_csv_file_format_list__class_2"></td>
+                                    <td id="product_csv_file_format_list__date"></td>
+                                    <td id="product_csv_file_format_list__code"></td>
+                                    <td id="product_csv_file_format_list__stock">在庫数無制限フラグが0の場合<br>0以上の数値を設定</td>
+                                    <td id="product_csv_file_format_list__stock_nolimit_flg">必須</td>
+                                    <td id="product_csv_file_format_list__limit">0以上の数値を設定</td>
+                                    <td id="product_csv_file_format_list__price_2">0以上の数値を設定</td>
+                                    <td id="product_csv_file_format_list__price_1">必須<br>0以上の数値を設定</td>
+                                    <td id="product_csv_file_format_list__delivery_fee">商品ごとの送料設定が有効の場合<br>0以上の数値を設定</td>
+                                    <td id="product_csv_file_format_list__category_delete_flg">設定されていない場合<br>0を登録</td>
                                 </tr>
                             </tbody>
                         </table>

--- a/src/Eccube/Resource/template/admin/Product/index.twig
+++ b/src/Eccube/Resource/template/admin/Product/index.twig
@@ -175,32 +175,32 @@ $(function() {
                             <div class="row">
                                 <div class="col-md-6">
                                     <ul id="product_search_result__state_menu" class="link-with-bar">
-                                    <li>
+                                    <li id="product_search_result__link_product_page">
                                         {% if page_status is null %}
-                                        <a>すべて</a>
+                                        <a id="link__product_page--disable">すべて</a>
                                         {% else %}
-                                        <a href="{{ path('admin_product_page', {'page_no': page_no} ) }}">すべて</a>
+                                        <a id="link__product_page--enable" href="{{ path('admin_product_page', {'page_no': page_no} ) }}">すべて</a>
                                         {% endif %}
                                     </li>
                                     {% for disp in disps %}
-                                      <li>
+                                      <li id="product_search_result__link_product_page--{{ disp.id }}_enable">
                                       {% if page_status == disp.id %}
-                                      <a>{{ disp.name|e }}</a>
+                                      <a id="link__product_page--{{ disp.id }}_diable">{{ disp.name|e }}</a>
                                       {% else %}
-                                      <a href="{{ path('admin_product_page', {'page_no': page_no, 'status': disp.id} ) }}">{{ disp.name|e }}</a>
+                                      <a id="link__product_page--{{ disp.id }}_enable" href="{{ path('admin_product_page', {'page_no': page_no, 'status': disp.id} ) }}">{{ disp.name|e }}</a>
                                       {% endif %}
                                       </li>
                                     {% endfor %}
-                                      <li>
+                                      <li id="product_search_result__link_product_page--{{ disp.id }}_enable">
                                       {% if page_status == app.config.admin_product_stock_status %}
-                                          <a>{{ app.translator.trans('admin.product.search.stock') }}</a>
+                                          <a id="link__product_page--disable">{{ app.translator.trans('admin.product.search.stock') }}</a>
                                       {% else %}
-                                          <a href="{{ path('admin_product_page', {'page_no': page_no, 'status': app.config.admin_product_stock_status} ) }}">{{ app.translator.trans('admin.product.search.stock') }}</a>
+                                          <a id="link__product_page--enable" href="{{ path('admin_product_page', {'page_no': page_no, 'status': app.config.admin_product_stock_status} ) }}">{{ app.translator.trans('admin.product.search.stock') }}</a>
                                       {% endif %}
                                       </li>
                                     </ul>
                                 </div>
-                                <div class="col-md-6">
+                                <div  class="col-md-6">
                                     <ul class="sort-dd">
                                     <li id="product_search_result__display_item_total_menu" class="dropdown">
                                         {% for pageMax in pageMaxis if pageMax.name == page_count %}
@@ -208,15 +208,15 @@ $(function() {
                                             <ul class="dropdown-menu">
                                         {% endfor %}
                                         {% for pageMax in pageMaxis if pageMax.name != page_count %}
-                                                <li><a href="{{ path('admin_product_page', {'page_no': 1, 'page_count': pageMax.name}) }}">{{ pageMax.name|e }}件</a></li>
+                                                <li id="product_search_result__link_result_product_page"><a id="link__result_product_page" href="{{ path('admin_product_page', {'page_no': 1, 'page_count': pageMax.name}) }}">{{ pageMax.name|e }}件</a></li>
                                         {% endfor %}
                                             </ul>
                                     </li>
                                     <li id="product_search_result__csv_menu" class="dropdown">
                                         <a class="dropdown-toggle" data-toggle="dropdown">CSVダウンロード<svg class="cb cb-angle-down icon_down"><use xlink:href="#cb-angle-down"></svg></a>
                                         <ul class="dropdown-menu">
-                                            <li><a href="{{ url('admin_product_export') }}">CSVダウンロード</a></li>
-                                            <li><a href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_PRODUCT') }) }}">出力項目設定</a></li>
+                                            <li id="product_search_result__link_product_export"><a id="link__product_export" href="{{ url('admin_product_export') }}">CSVダウンロード</a></li>
+                                            <li id="product_search_result__link_setting_shop_csv"><a id="link__setting_shop_csv" href="{{ url('admin_setting_shop_csv', { id : constant('\\Eccube\\Entity\\Master\\CsvType::CSV_TYPE_PRODUCT') }) }}">出力項目設定</a></li>
                                         </ul>
                                     </li>
                                     </ul>
@@ -226,34 +226,34 @@ $(function() {
                                 <div class="tableish tableish-striped">
 
                                     {% for Product in pagination %}
-                                        <div id="product_search_result__item_box--{{ loop.index }}" class="item_box tr">
-                                            <div id="product_search_result__item_id--{{ loop.index }}" class="item_id td">
+                                        <div id="product_search_result__item_box--{{ Product.id }}" class="item_box tr">
+                                            <div id="product_search_result__item_id--{{ Product.id }}" class="item_id td">
                                                 {{Product.id}}
                                             </div>
 
-                                            <div id="product_search_result__item_image--{{ loop.index }}" class="item_photo td">
+                                            <div id="product_search_result__item_image--{{ Product.id }}" class="item_photo td">
                                                 <a href="{{ url('admin_product_product_edit', { id : Product.id }) }}">
                                                 	<img src="{{ app.config.image_save_urlpath }}/{{ Product.mainFileName|no_image_product }}" />
                                                 </a>
                                             </div>
-                                            <div id="product_search_result__item_edit--{{ loop.index }}" class="item_detail td">
+                                            <div id="product_search_result__item_edit--{{ Product.id }}" class="item_detail td">
                                                 <a href="{{ url('admin_product_product_edit', { id : Product.id }) }}">
                                                     {{ Product.name }}
                                                 </a><br>
-                                                <span id="product_search_result__item_class--{{ loop.index }}">
+                                                <span id="product_search_result__item_class--{{ Product.id }}">
                                                     {{ Product.code_min }}
                                                     {% if Product.code_min != Product.code_max %} ～ {{ Product.code_max }}
                                                     {% endif %}
                                                 </span>
                                             </div>
                                             <div class="icon_edit td">
-                                                <div id="product_search_result__item_box_edit_menu--{{ loop.index }}" class="dropdown">
+                                                <div id="product_search_result__item_box_edit_menu--{{ Product.id }}" class="dropdown">
                                                     <a class="dropdown-toggle" data-toggle="dropdown"><svg class="cb cb-ellipsis-h"><use xlink:href="#cb-ellipsis-h"></svg></a>
                                                     <ul class="dropdown-menu dropdown-menu-right">
-                                                    <li><a href="{{ url('admin_product_product_class', { id : Product.id }) }}">規格</a></li>
-                                                    <li><a href="{{ url('admin_product_product_display', {'id' : Product.id}) }}" target="_blank">確認</a></li>
-                                                    <li><a href="#" onclick="fnCopy('{{ url('admin_product_product_copy', {'id' : Product.id}) }}');return false;">複製</a></li>
-                                                    <li><a href="{{ url('admin_product_product_delete', {'id' : Product.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-message="商品情報を削除してもよろしいですか？">削除</a></li>
+                                                    <li id="product_search_result__link_product_product_class--{{ Product.id }}"><a id="link__product_product_class--{{ Product.id }}" href="{{ url('admin_product_product_class', { id : Product.id }) }}">規格</a></li>
+                                                    <li id="product_search_result__link_product_product_display--{{ Product.id }}"><a id="link__product_product_display--{{ Product.id }}" href="{{ url('admin_product_product_display', {'id' : Product.id}) }}" target="_blank">確認</a></li>
+                                                    <li id="product_search_result__link_product_product_copy--{{ Product.id }}"><a id="link__product_product_copy--{{ Product.id }}" href="#" onclick="fnCopy('{{ url('admin_product_product_copy', {'id' : Product.id}) }}');return false;">複製</a></li>
+                                                    <li id="product_search_result__link_product_product_delete--{{ Product.id }}"><a id="link__product_product_delete--{{ Product.id }}" href="{{ url('admin_product_product_delete', {'id' : Product.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-message="商品情報を削除してもよろしいですか？">削除</a></li>
                                                     </ul>
                                                 </div>
                                             </div>

--- a/src/Eccube/Resource/template/admin/Product/product.twig
+++ b/src/Eccube/Resource/template/admin/Product/product.twig
@@ -358,8 +358,8 @@ function fnClass(action) {
                     </div>
 
                     <div id="product_edit__link" class="row hidden-xs hidden-sm">
-                        <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
-                            <p><a id="link-back" href="{{ url('admin_product') }}">検索画面に戻る</a></p>
+                        <div id="product_edit__link_product_back"class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
+                            <p><a id="link__product_back" href="{{ url('admin_product') }}">検索画面に戻る</a></p>
                         </div>
                     </div>
 
@@ -378,18 +378,18 @@ function fnClass(action) {
                                     </div>
                                 </div>
                                 <div id="product_edit_aside_column__button_confirm" class="row text-center">
-                                    <div class="col-sm-6 col-sm-offset-3 col-md-12 col-md-offset-0">
-                                        <button id="button__confirm" type="submit" class="btn btn-primary btn-block btn-lg prevention-btn prevention-mask" >商品を登録</button>
+                                    <div id="product_edit_aside_column__button_product_edit_confirm" class="col-sm-6 col-sm-offset-3 col-md-12 col-md-offset-0">
+                                        <button id="button__product_edit_confirm" type="submit" class="btn btn-primary btn-block btn-lg prevention-btn prevention-mask" >商品を登録</button>
                                     </div>
                                 </div>
                                 <div id="product_edit_aside_column__button_class" class="row text-center with-border">
-                                    <div class="col-sm-6 col-sm-offset-3 col-md-12 col-md-offset-0">
+                                    <div id="product_edit_aside_column__button_product_edit_class"  class="col-sm-6 col-sm-offset-3 col-md-12 col-md-offset-0">
                                         {% if id is null %}
-                                            <button id="product_edit_aside_column__button_class--disable" class="btn btn-default btn-block btn-sm" disabled>
+                                            <button id="button__product_edit_class--disable" class="btn btn-default btn-block btn-sm" disabled>
                                                 規格設定
                                             </button>
                                         {% else %}
-                                            <button id="product_edit_aside_column__button_class--enable" class="btn btn-default btn-block btn-sm" onclick="fnClass('{{ url('admin_product_product_class', { 'id' : id }) }}');return false;">
+                                            <button id="button__product_edit_class--enable" class="btn btn-default btn-block btn-sm" onclick="fnClass('{{ url('admin_product_product_class', { 'id' : id }) }}');return false;">
                                                 規格設定
                                             </button>
                                         {% endif %}
@@ -399,34 +399,34 @@ function fnClass(action) {
                                     <div class="col-sm-6 col-sm-offset-3 col-md-12 col-md-offset-0">
                                         <ul class="col-3">
                                             {% if id is null %}
-                                                <li>
-                                                    <button id="product_edit_aside_column__button_menu_display--disable" class="btn btn-default btn-block btn-sm" disabled>
+                                                <li id="product_edit_aside_column__button_menu_display--disable" >
+                                                    <button id="button__menu_display--disable" class="btn btn-default btn-block btn-sm" disabled>
                                                         確認
                                                     </button>
                                                 </li>
-                                                <li>
-                                                    <button id="product_edit_aside_column__button_menu_copy--disable" class="btn btn-default btn-block btn-sm" disabled>
+                                                <li id="product_edit_aside_column__button_menu_copy--disable">
+                                                    <button id="button__menu_copy--disable" class="btn btn-default btn-block btn-sm" disabled>
                                                         複製
                                                     </button>
                                                 </li>
-                                                <li>
-                                                    <button id="product_edit_aside_column__button_menu_delete--disable" class="btn btn-default btn-block btn-sm" disabled>
+                                                <li id="product_edit_aside_column__button_menu_delete--disable">
+                                                    <button id="button__menu_delete--disable" class="btn btn-default btn-block btn-sm" disabled>
                                                         削除
                                                     </button>
                                                 </li>
                                             {% else %}
-                                                <li>
-                                                    <a id="product_edit_aside_column__button_menu_display--enable" class="btn btn-default btn-block btn-sm" href="{{ url('admin_product_product_display', {'id' : id}) }}" target="_blank">
+                                                <li id="product_edit_aside_column__button_menu_display--enable">
+                                                    <a id="button__menu_display--enable" class="btn btn-default btn-block btn-sm" href="{{ url('admin_product_product_display', {'id' : id}) }}" target="_blank">
                                                         確認
                                                     </a>
                                                 </li>
-                                                <li>
-                                                    <button id="product_edit_aside_column__button_menu_copy--enable" class="btn btn-default btn-block btn-sm" onclick="fnCopy('{{ url('admin_product_product_copy', {'id' : id}) }}');return false;">
+                                                <li id="product_edit_aside_column__button_menu_copy--enable" >
+                                                    <button id="button__menu_copy--enable" class="btn btn-default btn-block btn-sm" onclick="fnCopy('{{ url('admin_product_product_copy', {'id' : id}) }}');return false;">
                                                         複製
                                                     </button>
                                                 </li>
-                                                <li>
-                                                     <a id="product_edit_aside_column__button_menu_delete--enable" class="btn btn-default btn-block btn-sm" href="{{ url('admin_product_product_delete', {'id' : Product.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-message="この商品情報を削除してもよろしいですか？">
+                                                <li id="product_edit_aside_column__button_menu_delete--enable">
+                                                     <a id="button__menu_delete--enable" class="btn btn-default btn-block btn-sm" href="{{ url('admin_product_product_delete', {'id' : Product.id}) }}" {{ csrf_token_for_anchor() }} data-method="delete" data-message="この商品情報を削除してもよろしいですか？">
                                                         削除
                                                     </a>
                                                 </li>

--- a/src/Eccube/Resource/template/admin/Product/product_class.twig
+++ b/src/Eccube/Resource/template/admin/Product/product_class.twig
@@ -141,29 +141,29 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 
 {% block main %}
-<div class="row">
+<div id="product_class" class="row">
     <div class="col-md-12">
         <form class="form-inline" method="post" action="{{ url('admin_product_product_class', {id : Product.id}) }}">
-            <div id="product_box" class="box">
-                <div id="product_box__head" class="box-header">
+            <div id="product_class_box" class="box">
+                <div id="product_class_box__head" class="box-header">
                     商品名 : <h3 class="box-title">{{ Product.name }}</h3>
                 </div><!-- /.box-header -->
-                <div id="product_box__body" class="box-body" style="padding-bottom: 30px;">
+                <div id="product_class_box__body" class="box-body" style="padding-bottom: 30px;">
                     {% if not_product_class  %}
                         {{ form_widget(form._token) }}
-                        <button type="submit" class="btn btn-primary pull-right">商品規格の設定</button>
-                        <div class="form-horizontal">
+                        <button id="button__product_class_edit" type="submit" class="btn btn-primary pull-right">商品規格の設定</button>
+                        <div id="product_class_box__name" class="form-horizontal">
                             {{ form_widget(form.class_name1) }}
                             {{ form_errors(form.class_name1) }}
                             {{ form_widget(form.class_name2) }}
                             {{ form_errors(form.class_name2) }}
                         </div>
                     {% else %}
-                        <button type="button" id="delete" class="btn btn-default pull-right" name="mode" value="delete">商品規格を初期化</button>
+                        <button id="button__product_class_delete" type="button" id="delete" class="btn btn-default pull-right" name="mode" value="delete">商品規格を初期化</button>
                         <div>
-                          規格1 : <strong>{{ class_name1 }}</strong>
+                          規格1 : <strong id="product_class_box__class_name1">{{ class_name1 }}</strong>
                           {% if class_name2 is not null %}
-                          <br>規格2 : <strong>{{ class_name2 }}</strong>
+                          <br>規格2 : <strong id="product_class_box__class_name2">{{ class_name2 }}</strong>
                           {% endif %}
                         </div>
                     {% endif %}
@@ -178,60 +178,60 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% if classForm is not null %}
 <form id="product-class-form" class="form-inline" method="post" action="{{ url('admin_product_product_class_edit', { id : Product.id}) }}">
 {{ form_widget(classForm._token) }}
-<div class="row">
+<div id="product_class_result" class="row">
     <div class="col-md-12">
-        <div class="box">
+        <div id="product_class_result_box" class="box">
             {% if classForm.product_classes|length > 0 and has_class_category_flg %}
-            <div id="product_search__head" class="box-header">
-                <button id="product_box_copy" type="button" id="copy" class="btn btn-default pull-right btn-xs">1行目のデータをコピーする</button>
+            <div id="product_class_result_box__header" class="box-header">
+                <button id="button__product_class_result" type="button" id="copy" class="btn btn-default pull-right btn-xs">1行目のデータをコピーする</button>
                 <h3 class="box-title">検索結果 <span class="normal"><strong>{{ classForm.product_classes|length }} 件</strong> が該当しました</span></h3>
                 {% if error is not null %}
                     <div class="text-danger">{{ error.message }}</div>
                 {% endif %}
             </div><!-- /.box-header -->
-            <div id="product_class_list" class="box-body no-padding">
-                <div class="table_list">
+            <div id="product_class_result_box__body" class="box-body no-padding">
+                <div id="product_class_result_list" class="table_list">
                     <div class="table-responsive with-border table-menu table-responsive-overflow">
                         <table class="table table-striped">
                             <thead>
-                                <tr id="product_class_list__head">
-                                    <th id="product_class_list__head__regist" class="text-center">登録<input id="add-all" type="checkbox" value="0"></th>
-                                    <th id="product_class_list__head__class_category1">規格1</th>
-                                    <th id="product_class_list__head__class_category2">規格2</th>
-                                    <th id="product_class_list__head__code">商品コード</th>
-                                    <th id="product_class_list__head__stock">在庫数</th>
-                                    <th id="product_class_list__head__sale_limit">販売制限数</th>
-                                    <th id="product_class_list__head__price01">通常価格(円)</th>
-                                    <th id="product_class_list__head__price02">販売価格(円)</th>
+                                <tr id="product_class_result_list">
+                                    <th id="product_class_result_list__header_add" class="text-center">登録<input id="add-all" type="checkbox" value="0"></th>
+                                    <th id="product_class_result_list__header_class_category1">規格1</th>
+                                    <th id="product_class_result_list__header_class_category2">規格2</th>
+                                    <th id="product_class_result_list__header_code">商品コード</th>
+                                    <th id="product_class_result_list__header_stock">在庫数</th>
+                                    <th id="product_class_result_list__header_sale_limit">販売制限数</th>
+                                    <th id="product_class_result_list__header_price01">通常価格(円)</th>
+                                    <th id="product_class_result_list__header_price02">販売価格(円)</th>
                                     {% if BaseInfo.option_product_delivery_fee %}
-                                    <th id="product_class_list__head__delivery_fee">送料</th>
+                                    <th id="product_class_result_list__header_delivery_fee">送料</th>
                                     {% endif %}
-                                    <th id="product_class_list__head__delivery_date">お届け可能日</th>
+                                    <th id="product_class_result_list__header_delivery_date">お届け可能日</th>
                                     {% if BaseInfo.option_product_tax_rule %}
-                                    <th id="product_class_list__head__tax_rate">販売税率</th>
+                                    <th id="product_class_result_list__header_tax_rate">販売税率</th>
                                     {% endif %}
-                                    <th id="product_class_list__head__product_type">商品種別</th>
+                                    <th id="product_class_result_list__header_product_type">商品種別</th>
                                 </tr>
                             </thead>
                             <tbody>
                             {% for product_class_form in classForm.product_classes %}
-                            <tr>
-                                <td id="product_class_list__head__regist--{{ loop.index }}" class="text-center">
+                            <tr id="product_class_result_list__item--{{ loop.index }}">
+                                <td id="product_class_result_list__add--{{ loop.index }}" class="text-center">
                                     {{ form_widget(product_class_form.add) }}
                                 </td>
-                                <td id="product_class_list__body__class_category1--{{ loop.index }}">
+                                <td id="product_class_result_list__class_category1--{{ loop.index }}">
                                     {{ product_class_form.vars.value.ClassCategory1 }}
                                     {{ form_widget(product_class_form.ClassCategory1) }}
                                 </td>
-                                <td id="product_class_list__body__class_category2--{{ loop.index }}">
+                                <td id="product_class_result_list__class_category2--{{ loop.index }}">
                                     {{ product_class_form.vars.value.ClassCategory2 }}
                                     {{ form_widget(product_class_form.ClassCategory2) }}
                                 </td>
-                                <td id="product_class_list__body__code--{{ loop.index }}">
+                                <td id="product_class_result_list__code--{{ loop.index }}">
                                     {{ form_widget(product_class_form.code) }}
                                     {{ form_errors(product_class_form.code) }}
                                 </td>
-                                <td id="product_class_list__body__stock--{{ loop.index }}">
+                                <td id="product_class_result_list__stock--{{ loop.index }}">
                                     {% if  product_class_form.vars.value.stock_unlimited %}
                                     {# 在庫無制限時のdisable #}
                                     {% endif %}
@@ -240,39 +240,39 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                                     {{ form_widget(product_class_form.stock_unlimited) }}
                                     {{ form_errors(product_class_form.stock_unlimited) }}
                                 </td>
-                                <td id="product_class_list__body__sale_limit--{{ loop.index }}">
+                                <td id="product_class_result_list__sale_limit--{{ loop.index }}">
                                     {{ form_widget(product_class_form.sale_limit) }}
                                     {{ form_errors(product_class_form.sale_limit) }}
                                 </td>
-                                <td id="product_class_list__body__price01--{{ loop.index }}" class="price_cell">
+                                <td id="product_class_result_list__price01--{{ loop.index }}" class="price_cell">
                                     {{ form_widget(product_class_form.price01, {'attr': {'class': 'notmoney'}}) }}
                                     {{ form_errors(product_class_form.price01) }}
                                 </td>
-                                <td id="product_class_list__body__price02--{{ loop.index }}" class="price_cell">
+                                <td id="product_class_result_list__price02--{{ loop.index }}" class="price_cell">
                                     {{ form_widget(product_class_form.price02, {'attr': {'class': 'notmoney'}}) }}
                                     {{ form_errors(product_class_form.price02) }}
                                 </td>
                                 {% if BaseInfo.option_product_delivery_fee %}
-                                <td id="product_class_list__body__delivery_fee--{{ loop.index }}">
+                                <td id="product_class_result_list__delivery_fee--{{ loop.index }}">
                                     {{ form_widget(product_class_form.delivery_fee, {'attr': {'class': 'notmoney'}}) }}
                                     {{ form_errors(product_class_form.delivery_fee) }}
                                 </td>
                                 {% endif %}
-                                <td id="product_class_list__body__delivery_date--{{ loop.index }}">
+                                <td id="product_class_result_list__delivery_date--{{ loop.index }}">
                                     {{ form_widget(product_class_form.delivery_date) }}
                                     {{ form_errors(product_class_form.delivery_date) }}
                                 </td>
                                 {% if BaseInfo.option_product_tax_rule %}
-                                <td id="product_class_list__body__tax_rate--{{ loop.index }}">
+                                <td id="product_class_result_list__tax_rate--{{ loop.index }}">
                                     {{ form_widget(product_class_form.tax_rate) }}
                                     {{ form_errors(product_class_form.tax_rate) }}
                                 </td>
                                 {% endif %}
-                                <td id="product_class_list__body__product_type--{{ loop.index }}">
+                                <td id="product_class_result_list__product_type--{{ loop.index }}">
                                     {{ form_widget(product_class_form.product_type) }}
                                     {{ form_errors(product_class_form.product_type) }}
                                 </td>
-                            </tr>
+                            </tr><!-- product_class_result_list__item-->
                             {% endfor %}
                             </tbody>
                         </table>
@@ -280,7 +280,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
                 </div>
             </div><!-- /.box-body -->
             {% else %}
-            <div id="product_class__header_error" class="box-header">
+            <div id="product_class_result_box__body_error" class="box-header">
                 <h3 class="box-title">検索条件に該当するデータがありませんでした。</h3>
             </div><!-- /.box-header -->
             {% endif %}
@@ -292,12 +292,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 <div id="product_class__button_area" class="row">
     <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
 {% if not_product_class  %}
-        <button id="regist" type="submit" class="btn btn-primary btn-lg btn-block" name="mode" value="edit">登録</button>
+        <button id="button__product_class_new" type="submit" class="btn btn-primary btn-lg btn-block" name="mode" value="edit">登録</button>
 {% else %}
         <input id="mode" type="hidden" name="mode">
-        <button type="submit" class="btn btn-primary btn-lg btn-block" name="mode" value="update">更新</button>
+        <button id="button__product_class_edit" type="submit" class="btn btn-primary btn-lg btn-block" name="mode" value="update">更新</button>
 {% endif %}
-        <p><a href="{{ url('admin_product') }}">前のページに戻る</a></p>
+        <p id="product_class__link_product_class_back" ><a id="link__product_class_back" href="{{ url('admin_product') }}">前のページに戻る</a></p>
     </div>
 </div>
 </form>


### PR DESCRIPTION
# 修正内容
## ID付与位置
- 各意味を持つブロックの一番外にある要素にIDを追加
- button/link要素にIDを付与
- button/link親要素にIDを付与
## ID命名規則
### 通常ブロック
- ページ名( twig名 )
- ページ名( twig名 )_box
- ページ名( twig名 )_box__header( 箇所により省略 )
- ページ名( twig名 )_box__body
- ページ名( twig名 )_list
- ページ名( twig名 )_item
- ページ名( twig名 )_[box]__menu / ページ名( twig名 )_menu
### リンク
- link__[url]
### ボタン
- button__[url]
- button__[url](一意にならない際はbox等を差し引いたブロック名)
### ボタン・リンクの親要素
- [ブロック名]__button_[url] / [ブロック名]__link_[url]
## ループしているitemについて
### 項目にIDがある場合
- [ブロック名]__item--{{ 例.) Product.id }}
### 項目にIDがない場合
- [ブロック名]__item--{{ loop.index }}
